### PR TITLE
Fix visualizer startup and session state

### DIFF
--- a/scripts/improved_frontend.py
+++ b/scripts/improved_frontend.py
@@ -26,7 +26,7 @@ if 'visualizer_process' not in st.session_state:
 def start_visualizer():
     if st.session_state.visualizer_process is None:
         try:
-            cmd = ["python", "scripts/visualizer.py", "--path", "demo_evolution_data", "--host", "127.0.0.1", "--port", "8081"]
+            cmd = ["python3", "scripts/visualizer.py", "--path", "demo_evolution_data", "--host", "127.0.0.1", "--port", "8081"]
             st.session_state.visualizer_process = subprocess.Popen(cmd)
             time.sleep(2)
             return True
@@ -36,7 +36,8 @@ def start_visualizer():
     return True
 
 def stop_visualizer():
-    if st.session_state.visualizer_process:
+    # Check if session_state exists and has the attribute
+    if hasattr(st, 'session_state') and hasattr(st.session_state, 'visualizer_process') and st.session_state.visualizer_process:
         st.session_state.visualizer_process.terminate()
         st.session_state.visualizer_process = None
 


### PR DESCRIPTION
Fixes visualizer startup by using `python3` and prevents `AttributeError` during shutdown by adding session state checks.

The `python` command was not found on the system, causing the visualizer to fail with `Errno 2`. Changing it to `python3` resolves this. The `AttributeError` occurred because `stop_visualizer` was called as an `atexit` callback when `st.session_state` might no longer be available or properly initialized, so checks were added to ensure safe access.

---
<a href="https://cursor.com/background-agent?bcId=bc-d44bfdf4-afb2-4c29-a11a-88525c660979">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d44bfdf4-afb2-4c29-a11a-88525c660979">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

