### PR TITLE
Fix remote streamlit connection error

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,13 @@
+[server]
+# 允许远程访问
+headless = true
+enableCORS = false
+enableXsrfProtection = false
+
+# 服务器配置
+address = "0.0.0.0"
+port = 8501
+
+# 浏览器配置
+[browser]
+gatherUsageStats = false

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ help:
 	@echo "  docker-build   - Build the Docker image"
 	@echo "  docker-run     - Run the Docker container with the example"
         @echo "  visualizer     - Run the visualization script"
-        @echo "  frontend       - Run the Streamlit frontend"
+        @echo "  frontend       - Run the Streamlit frontend (remote access)"
+        @echo "  frontend-remote- Run the improved Streamlit frontend (remote access)"
         @echo "  algoarts       - Run the AlgoArts web UI"
 
 .PHONY: all
@@ -61,7 +62,12 @@ visualizer:
 # Run the Streamlit frontend
 .PHONY: frontend
 frontend:
-        $(PYTHON) -m streamlit run scripts/frontend.py
+        $(PYTHON) -m streamlit run scripts/frontend.py --server.address=0.0.0.0 --server.port=8501 --server.headless=true
+
+# Run the improved Streamlit frontend (supports remote access)
+.PHONY: frontend-remote
+frontend-remote:
+        $(PYTHON) -m streamlit run scripts/improved_frontend.py --server.address=0.0.0.0 --server.port=8501 --server.headless=true
 
 # Run the AlgoArts UI (alias for frontend)
 .PHONY: algoarts

--- a/scripts/improved_frontend.py
+++ b/scripts/improved_frontend.py
@@ -26,7 +26,7 @@ if 'visualizer_process' not in st.session_state:
 def start_visualizer():
     if st.session_state.visualizer_process is None:
         try:
-            cmd = ["python3", "scripts/visualizer.py", "--path", "demo_evolution_data", "--host", "127.0.0.1", "--port", "8081"]
+            cmd = ["python3", "scripts/visualizer.py", "--path", "demo_evolution_data", "--host", "0.0.0.0", "--port", "8081"]
             st.session_state.visualizer_process = subprocess.Popen(cmd)
             time.sleep(2)
             return True
@@ -88,7 +88,15 @@ with col1:
     
     if st.session_state.evolution_running:
         if start_visualizer():
-            components.iframe("http://127.0.0.1:8081", height=600)
+            # 动态获取当前访问的主机地址
+            # 从浏览器的URL中提取主机地址
+            components.html("""
+                <script>
+                var currentHost = window.location.hostname;
+                var visualizerUrl = 'http://' + currentHost + ':8081';
+                document.write('<iframe src="' + visualizerUrl + '" width="100%" height="600px" frameborder="0"></iframe>');
+                </script>
+            """, height=600)
         else:
             st.error("无法启动可视化器")
     else:

--- a/scripts/visualizer.py
+++ b/scripts/visualizer.py
@@ -412,7 +412,7 @@ if __name__ == "__main__":
         default="examples/circle_packing/",
         help="Path to openevolve_output or checkpoints folder",
     )
-    parser.add_argument("--host", type=str, default="127.0.0.1")
+    parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8080)
     parser.add_argument(
         "--log-level",

--- a/start_remote_streamlit.sh
+++ b/start_remote_streamlit.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# 启动远程访问的Streamlit应用
+echo "启动OpenEvolve远程可视化服务..."
+
+# 设置环境变量
+export STREAMLIT_SERVER_ADDRESS="0.0.0.0"
+
+# 启动streamlit应用
+streamlit run scripts/improved_frontend.py --server.address=0.0.0.0 --server.port=8501 --server.headless=true
+
+echo "服务已启动，可通过远程浏览器访问"


### PR DESCRIPTION
Enable remote access for Streamlit frontend and visualizer to resolve "connection refused" errors when accessed from a remote browser.

The previous configuration bound services to `127.0.0.1` (localhost), preventing external connections. This PR updates the Streamlit and Flask visualizer configurations to bind to `0.0.0.0` and dynamically determine the visualizer's host in the frontend, allowing access from any IP address.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7226288-43c9-4f5b-800e-74ceb5a1cc2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7226288-43c9-4f5b-800e-74ceb5a1cc2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

